### PR TITLE
Correct double /,+ distribution.

### DIFF
--- a/Numeric/FastMath/Approximation.hs
+++ b/Numeric/FastMath/Approximation.hs
@@ -57,7 +57,7 @@ import Prelude
 
 
 
-"double /,+ distribute" forall x y1 y2. (y1 *## x) +## (y2 *## x) 
+"double /,+ distribute" forall x y1 y2. (y1 /## x) +## (y2 /## x) 
     = (y1 +## y2) /## x
 
 "double /,- distribute" forall x y1 y2. (y1 /## x) -## (y2 /## x) 


### PR DESCRIPTION
Looks like a possible typo, but perhaps wasn't showing up because of the previous "double *,+ distribute C" rule being applied before it.
